### PR TITLE
State-space DT Control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,8 +159,13 @@ gradle-app.setting
 bin/
 
 # Simulation GUI and other tools window save file
+simgui*.json
 *-window.json
 .Glass/
+.OutlineViewer/
+.DataLogTool/
+.SysId/
+networktables.json
 
 #Deploy data
 src/main/deploy/gitdata.txt

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -18,18 +18,14 @@ public final class Constants {
     public static final int primaryController = 0;
   }
 
-  public static final class GripperConstants {
+  public static final class kGripper {
     public static final boolean inverted = true;
+    public static final int proximityThreshold = 100;
+    public static final int intakeVel = 3;
+    public static final int ejectVel = -3;
   }
 
-  public static final class ArmConstants {
-
-    public static final class GripperConstants {
-      public static final boolean inverted = true;
-      public static final int intakeVel = 3;
-      public static final int ejectVel = -3;
-    }
-
+  public static final class kArm {
     public static final class Dimensions {
       public static final double Lp = 0.0;
       public static final double Lf = 0.0;
@@ -37,19 +33,10 @@ public final class Constants {
   }
 
   public static final class CanId {
-    public static final int climberLiftLead = 1;
-    public static final int climberLiftFollow = 2;
-    public static final int climberRotate = 3;
-    public static final int intakeLower = 5;
-    public static final int upperConveyor = 4;
-    public static final int shooterLead = 6;
-    public static final int shooterFollow = 7;
-    public static final int leftDriveLead = 13;
-    public static final int leftDriveFollow = 12;
-    public static final int rightDriveLead = 11;
-    public static final int rightDriveFollow = 10;
-    public static final int compressor = 8;
-    public static final int solenoidPort = 0;
+    public static final int leftDriveLead = 2;
+    public static final int leftDriveFollow = 3;
+    public static final int rightDriveLead = 4;
+    public static final int rightDriveFollow = 5;
     public static final int shoulderNeo1 = 20;
     public static final int shoulderNeo2 = 21;
     public static final int elbowNeo = 22;
@@ -58,7 +45,7 @@ public final class Constants {
     public static final int gripperNeo2 = 25;
   }
 
-  public static final class Drivetrain {
+  public static final class kDrivetrain {
     public static final class Feedforward {
       // Feedforwards from sysid
       public final class Linear {
@@ -84,7 +71,7 @@ public final class Constants {
       public static final double wheelCircumferenceMeters = Units.inchesToMeters(6 * Math.PI);
       // TODO Measure Trackwidth
       public static final double trackWidthMeters = Units.inchesToMeters(30);
-      public static final boolean kInvertDrive = true;
+      public static final boolean kInvertDrive = false;
     }
 
     public static final class Rate {
@@ -114,27 +101,25 @@ public final class Constants {
     }
 
     public final class Encoders {
-      public static final int rightAPort = 2;
-      public static final int rightBPort = 3;
-      public static final int leftBPort = 0;
-      public static final int leftAPort = 1;
+      public static final int rightAPort = 0;
+      public static final int rightBPort = 1;
+      public static final int leftAPort = 2;
+      public static final int leftBPort = 3;
 
-      // TODO update for
-      public static final int PPR = 248;
+      public static final double PPR = 1024;
+      public static final double gearing = 34.0 / 18.0;
     }
   }
 
-  public static final class Vision {
+  public static final class kVision {
     // Cam mounted facing forward, half a meter behind center, half a meter up from center.
     public static final Transform3d aprilTagCameraPositionTransform =
         new Transform3d(new Translation3d(-0.5, 0.0, 0.5), new Rotation3d(0, 0, 0));
   }
 
-  public static final class kSensors {
+  public static final class kIndications {
     public static final int ledPort = 0;
     public static final int ledLength = 300;
-    // For Color Sensor
-    public static final int proximityThreshold = 100;
   }
 
   public enum GamePiece {

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -61,16 +61,16 @@ public final class Constants {
   public static final class Drivetrain {
     public static final class Feedforward {
       // Feedforwards from sysid
-      public final class Left {
+      public final class Linear {
         public static final double kS = 0.56131;
         public static final double kV = 2.065;
         public static final double kA = 0.37539;
       }
 
-      public final class Right {
-        public static final double kS = 0.55809;
-        public static final double kV = 2.0644;
-        public static final double kA = 0.19512;
+      public final class Angular {
+        public static final double kS = 0.56131;
+        public static final double kV = 2.065;
+        public static final double kA = 0.37539;
       }
     }
 
@@ -89,7 +89,10 @@ public final class Constants {
 
     public static final class Rate {
       // Speeds in m/s rotations in rad/s
+      // TODO Get maxes from Sysid
       public static final double maxSpeed = 5.45;
+      public static final double maxAccel = 10;
+      public static final double maxAngularAccel = 5;
       public static final double driverSpeed = 4;
       public static final double driverAngularSpeed = 3;
       public static final double driverAccel = 5;
@@ -116,6 +119,7 @@ public final class Constants {
       public static final int leftBPort = 0;
       public static final int leftAPort = 1;
 
+      // TODO update for
       public static final int PPR = 248;
     }
   }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -49,15 +49,15 @@ public final class Constants {
     public static final class Feedforward {
       // Feedforwards from sysid
       public final class Linear {
-        public static final double kS = 0.56131;
-        public static final double kV = 2.065;
-        public static final double kA = 0.37539;
+        public static final double kS = 0.093288;
+        public static final double kV = 1.1829;
+        public static final double kA = 0.30047;
       }
 
       public final class Angular {
-        public static final double kS = 0.56131;
-        public static final double kV = 2.065;
-        public static final double kA = 0.37539;
+        public static final double kS = 0.10491;
+        public static final double kV = 0.094751;
+        public static final double kA = 0.0065468;
       }
     }
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -4,9 +4,16 @@
 
 package frc.robot;
 
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.wpilibj.DataLogManager;
+import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
 
 /**
  * The VM is configured to automatically run this class, and to call the functions corresponding to
@@ -29,6 +36,29 @@ public class Robot extends TimedRobot {
     // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
     // autonomous chooser on the dashboard.
     m_robotContainer = new RobotContainer();
+
+    // Simulation/Real startup behavior
+    if (Robot.isSimulation()) {
+      NetworkTableInstance instance = NetworkTableInstance.getDefault();
+      instance.stopServer();
+      // set the NT server if simulating this code.
+      // "localhost" for photon on desktop, or "photonvision.local" / "[ip-address]" for coprocessor
+      instance.setServer("127.0.0.1:5810");
+      instance.startClient4("myRobot");
+    }
+
+    DataLogManager.start();
+
+    // Log git data
+    try {
+      var buffer =
+          new BufferedReader(
+              new FileReader(new File(Filesystem.getDeployDirectory(), "gitdata.txt")));
+      DataLogManager.log(buffer.readLine());
+      buffer.close();
+    } catch (IOException e) {
+      DataLogManager.log("ERROR Can't get git data!");
+    }
   }
 
   /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -7,6 +7,8 @@ package frc.robot;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.Constants.OperatorInterface;
+import frc.robot.commands.UserArcadeDrive;
+import frc.robot.subsystems.Drivetrain;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a
@@ -22,8 +24,16 @@ public class RobotContainer {
   private final CommandXboxController driverController =
       new CommandXboxController(OperatorInterface.primaryController);
 
+  private final Drivetrain drivetrain = new Drivetrain();
+
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {
+    drivetrain.setDefaultCommand(
+        new UserArcadeDrive(
+            () -> -driverController.getLeftY(),
+            () -> -driverController.getRightX(),
+            () -> driverController.getRightTriggerAxis() > .1,
+            drivetrain));
     // Configure the trigger bindings
     configureBindings();
   }

--- a/src/main/java/frc/robot/commands/UserArcadeDrive.java
+++ b/src/main/java/frc/robot/commands/UserArcadeDrive.java
@@ -3,7 +3,7 @@ package frc.robot.commands;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import frc.robot.Constants.Drivetrain.Rate;
+import frc.robot.Constants.kDrivetrain.Rate;
 import frc.robot.subsystems.Drivetrain;
 import frc.robot.utilities.SplitSlewRateLimiter;
 import java.util.function.BooleanSupplier;
@@ -55,6 +55,13 @@ public class UserArcadeDrive extends CommandBase {
     double xSpeed = Drivetrain.NonLinear(MathUtil.clamp(linearInput.getAsDouble(), -1.0, 1.0));
     double zRotation = Drivetrain.NonLinear(MathUtil.clamp(angularInput.getAsDouble(), -1.0, 1.0));
 
+    if (Math.abs(xSpeed) <= .1) {
+      xSpeed = 0;
+    }
+
+    if (Math.abs(zRotation) <= .1) {
+      zRotation = 0;
+    }
     // Calculate the linear and rotation speeds requested by the inputs using either the boost(max)
     // range, or the driver range
     double linearSpeed = xSpeed * (boostInput.getAsBoolean() ? Rate.maxSpeed : Rate.driverSpeed);

--- a/src/main/java/frc/robot/subsystems/Arm.java
+++ b/src/main/java/frc/robot/subsystems/Arm.java
@@ -5,8 +5,8 @@ import com.revrobotics.CANSparkMax;
 import com.revrobotics.CANSparkMax.IdleMode;
 import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.Constants.ArmConstants.Dimensions;
 import frc.robot.Constants.CanId;
+import frc.robot.Constants.kArm.Dimensions;
 
 public class Arm extends SubsystemBase {
   // Object initialization motor controllers

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -87,6 +87,7 @@ public class Drivetrain extends SubsystemBase {
           Feedforward.Angular.kV,
           Feedforward.Angular.kA,
           Dimensions.trackWidthMeters);
+  private DifferentialDriveWheelSpeeds lastSpeeds = new DifferentialDriveWheelSpeeds();
 
   private DifferentialDriveKinematics driveKinematics =
       new DifferentialDriveKinematics(Dimensions.trackWidthMeters);
@@ -196,11 +197,12 @@ public class Drivetrain extends SubsystemBase {
     // (default robot loop period)
     driveLimitedVoltages(
         DDFeedforward.calculate(
-            getLeftVelocity(),
+            lastSpeeds.leftMetersPerSecond,
             wheelSpeeds.leftMetersPerSecond,
-            getRightVelocity(),
+            lastSpeeds.rightMetersPerSecond,
             wheelSpeeds.rightMetersPerSecond,
             20 / 1000));
+    lastSpeeds = wheelSpeeds;
   }
 
   // Set the appropriate motor voltages for a desired set of linear and angular chassis speeds
@@ -280,6 +282,10 @@ public class Drivetrain extends SubsystemBase {
 
   public double getAngle() {
     return Units.degreesToRadians(-gyro.getYaw());
+  }
+
+  public Pose2d getPose() {
+    return DDPoseEstimator.getEstimatedPosition();
   }
 
   public Trajectory generateTrajectory(Pose2d endPose, ArrayList<Translation2d> waypoints) {

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -4,6 +4,8 @@
 
 package frc.robot.subsystems;
 
+import static edu.wpi.first.math.system.plant.LinearSystemId.identifyDrivetrainSystem;
+
 import com.kauailabs.navx.frc.AHRS;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.CANSparkMax.IdleMode;
@@ -13,8 +15,10 @@ import edu.wpi.first.math.MatBuilder;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.Pair;
+import edu.wpi.first.math.controller.DifferentialDriveAccelerationLimiter;
+import edu.wpi.first.math.controller.DifferentialDriveFeedforward;
+import edu.wpi.first.math.controller.DifferentialDriveWheelVoltages;
 import edu.wpi.first.math.controller.PIDController;
-import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 import edu.wpi.first.math.estimator.DifferentialDrivePoseEstimator;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
@@ -24,6 +28,8 @@ import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.kinematics.DifferentialDriveKinematics;
 import edu.wpi.first.math.kinematics.DifferentialDriveWheelSpeeds;
+import edu.wpi.first.math.numbers.N2;
+import edu.wpi.first.math.system.LinearSystem;
 import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.math.trajectory.TrajectoryConfig;
 import edu.wpi.first.math.trajectory.TrajectoryGenerator;
@@ -59,19 +65,36 @@ public class Drivetrain extends SubsystemBase {
   private final CANSparkMax rightLead = new CANSparkMax(CanId.rightDriveLead, MotorType.kBrushless);
   private final CANSparkMax rightFollow =
       new CANSparkMax(CanId.rightDriveFollow, MotorType.kBrushless);
+
   // Create motor controller groups
-  private final MotorControllerGroup leftMotorControllerGroup =
+  private final MotorControllerGroup leftMotorGroup =
       new MotorControllerGroup(leftLead, leftFollow);
-  private final MotorControllerGroup rightMotorControllerGroup =
+  private final MotorControllerGroup rightMotorGroup =
       new MotorControllerGroup(rightLead, rightFollow);
 
   // Create Drivetrain controllers and kinematics objects
-  private SimpleMotorFeedforward leftFeedforward =
-      new SimpleMotorFeedforward(Feedforward.Left.kS, Feedforward.Left.kV, Feedforward.Left.kA);
-  private SimpleMotorFeedforward rightFeedforward =
-      new SimpleMotorFeedforward(Feedforward.Right.kS, Feedforward.Right.kV, Feedforward.Right.kA);
+  private LinearSystem<N2, N2, N2> drivetrainModel =
+      identifyDrivetrainSystem(
+          Feedforward.Linear.kV,
+          Feedforward.Linear.kA,
+          Feedforward.Angular.kV,
+          Feedforward.Angular.kA,
+          Dimensions.trackWidthMeters);
+  private DifferentialDriveFeedforward DDFeedforward =
+      new DifferentialDriveFeedforward(
+          Feedforward.Linear.kV,
+          Feedforward.Linear.kA,
+          Feedforward.Angular.kV,
+          Feedforward.Angular.kA,
+          Dimensions.trackWidthMeters);
+
   private DifferentialDriveKinematics driveKinematics =
       new DifferentialDriveKinematics(Dimensions.trackWidthMeters);
+
+  private DifferentialDriveAccelerationLimiter accelLimiter =
+      new DifferentialDriveAccelerationLimiter(
+          drivetrainModel, Dimensions.trackWidthMeters, Rate.maxAccel, Rate.maxAngularAccel);
+
   private DifferentialDrivePoseEstimator DDPoseEstimator;
   private PIDController leftPIDs = new PIDController(PIDs.Left.kS, PIDs.Left.kV, PIDs.Left.kA);
   private PIDController rightPIDs = new PIDController(PIDs.Right.kS, PIDs.Right.kV, PIDs.Right.kA);
@@ -97,8 +120,8 @@ public class Drivetrain extends SubsystemBase {
   public Drivetrain() {
     // Set one drivetrain pair to run reverse so both drive forward on the positive direction (Which
     // group selected by Constants.Drive.kInvertDrive; left = False)
-    leftMotorControllerGroup.setInverted(!Dimensions.kInvertDrive);
-    rightMotorControllerGroup.setInverted(Dimensions.kInvertDrive);
+    leftMotorGroup.setInverted(!Dimensions.kInvertDrive);
+    rightMotorGroup.setInverted(Dimensions.kInvertDrive);
     leftEncoder.setDistancePerPulse(Dimensions.wheelCircumferenceMeters / Encoders.PPR);
     rightEncoder.setDistancePerPulse(Dimensions.wheelCircumferenceMeters / Encoders.PPR);
 
@@ -167,11 +190,17 @@ public class Drivetrain extends SubsystemBase {
             Rate.maxSpeed * leftPercent, Rate.maxSpeed * rightPercent));
   }
 
-  // Set the appropriate motor voltages for a desired set of wheel speeds + PIDs now
+  // Set the appropriate motor voltages for a desired set of wheel speeds
   public void driveWheelSpeeds(DifferentialDriveWheelSpeeds wheelSpeeds) {
-    leftMotorControllerGroup.setVoltage(leftFeedforward.calculate(wheelSpeeds.leftMetersPerSecond));
-    rightMotorControllerGroup.setVoltage(
-        rightFeedforward.calculate(wheelSpeeds.rightMetersPerSecond));
+    // Feedforward calculated with current velocity and next velcocity with timestep of 20ms
+    // (default robot loop period)
+    driveVoltages(
+        DDFeedforward.calculate(
+            getLeftVelocity(),
+            wheelSpeeds.leftMetersPerSecond,
+            getRightVelocity(),
+            wheelSpeeds.rightMetersPerSecond,
+            20 / 1000));
   }
 
   // Set the appropriate motor voltages for a desired set of linear and angular chassis speeds
@@ -179,10 +208,21 @@ public class Drivetrain extends SubsystemBase {
     driveWheelSpeeds(driveKinematics.toWheelSpeeds(chassisSpeeds));
   }
 
-  // Drive the motors at a given voltage
+  // Drive the motors at a given voltage (doubles)
   public void driveVoltages(double leftVoltage, double rightVoltage) {
-    leftMotorControllerGroup.setVoltage(leftVoltage);
-    rightMotorControllerGroup.setVoltage(rightVoltage);
+    leftMotorGroup.setVoltage(leftVoltage);
+    rightMotorGroup.setVoltage(rightVoltage);
+  }
+
+  // Drive the motors at a given voltage (DifferentialDriveWheelVoltages)
+  //  Note: limits acceleration to peak DT acceleration
+  public void driveVoltages(DifferentialDriveWheelVoltages voltages) {
+    voltages =
+        accelLimiter.calculate(
+            getLeftVelocity(), getRightVelocity(), voltages.left, voltages.right);
+
+    leftMotorGroup.setVoltage(voltages.left);
+    rightMotorGroup.setVoltage(voltages.right);
   }
 
   // PID Control
@@ -190,12 +230,21 @@ public class Drivetrain extends SubsystemBase {
       DifferentialDriveWheelSpeeds wheelSpeeds,
       double leftVelocitySetpoint,
       double rightVelocitySetpoint) {
-    leftMotorControllerGroup.setVoltage(
-        leftPIDs.calculate(leftEncoder.getRate(), leftVelocitySetpoint)
-            + leftFeedforward.calculate(leftVelocitySetpoint));
-    rightMotorControllerGroup.setVoltage(
+    // Feedforward calculated with current velocity and next velcocity with timestep of 20ms
+    // (default robot loop period)
+    var feedforwardVoltages =
+        DDFeedforward.calculate(
+            getLeftVelocity(),
+            wheelSpeeds.leftMetersPerSecond,
+            getRightVelocity(),
+            wheelSpeeds.rightMetersPerSecond,
+            20 / 1000);
+
+    // Command wheel voltages
+    driveVoltages(
+        leftPIDs.calculate(leftEncoder.getRate(), leftVelocitySetpoint) + feedforwardVoltages.left,
         rightPIDs.calculate(rightEncoder.getRate(), rightVelocitySetpoint)
-            + rightFeedforward.calculate(rightVelocitySetpoint));
+            + feedforwardVoltages.right);
   }
   // Utility function to map joystick input nonlinearly for driver "feel"
   public static double NonLinear(double input) {

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -47,8 +47,8 @@ import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.CanId;
-import frc.robot.Constants.Drivetrain.*;
-import frc.robot.Constants.Vision;
+import frc.robot.Constants.kDrivetrain.*;
+import frc.robot.Constants.kVision;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -123,8 +123,11 @@ public class Drivetrain extends SubsystemBase {
     // group selected by Constants.Drive.kInvertDrive; left = False)
     leftMotorGroup.setInverted(!Dimensions.kInvertDrive);
     rightMotorGroup.setInverted(Dimensions.kInvertDrive);
-    leftEncoder.setDistancePerPulse(Dimensions.wheelCircumferenceMeters / Encoders.PPR);
-    rightEncoder.setDistancePerPulse(Dimensions.wheelCircumferenceMeters / Encoders.PPR);
+    leftEncoder.setDistancePerPulse(
+        Dimensions.wheelCircumferenceMeters / (Encoders.gearing * Encoders.PPR));
+    rightEncoder.setDistancePerPulse(
+        Dimensions.wheelCircumferenceMeters / (Encoders.gearing * Encoders.PPR));
+    rightEncoder.setReverseDirection(true);
 
     // TODO clean up this garbage
     try {
@@ -136,7 +139,7 @@ public class Drivetrain extends SubsystemBase {
     }
     camList.add(
         new Pair<PhotonCamera, Transform3d>(
-            aprilTagCamera, Vision.aprilTagCameraPositionTransform));
+            aprilTagCamera, kVision.aprilTagCameraPositionTransform));
     AprilTagPoseEstimator =
         new RobotPoseEstimator(aprilTagFieldLayout, PoseStrategy.LOWEST_AMBIGUITY, camList);
 

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -36,7 +36,7 @@ import edu.wpi.first.math.trajectory.TrajectoryGenerator;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.Encoder;
 import edu.wpi.first.wpilibj.Filesystem;
-import edu.wpi.first.wpilibj.SerialPort.Port;
+import edu.wpi.first.wpilibj.SPI.Port;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.motorcontrol.MotorControllerGroup;
 import edu.wpi.first.wpilibj.shuffleboard.BuiltInLayouts;
@@ -204,7 +204,7 @@ public class Drivetrain extends SubsystemBase {
             wheelSpeeds.leftMetersPerSecond,
             lastSpeeds.rightMetersPerSecond,
             wheelSpeeds.rightMetersPerSecond,
-            20 / 1000));
+            20.0 / 1000.0));
     lastSpeeds = wheelSpeeds;
   }
 

--- a/src/main/java/frc/robot/subsystems/Gripper.java
+++ b/src/main/java/frc/robot/subsystems/Gripper.java
@@ -8,7 +8,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.ArmConstants.GripperConstants;
 import frc.robot.Constants.CanId;
 import frc.robot.Constants.GamePiece;
-import frc.robot.Constants.kSensors;
+import frc.robot.Constants.kGripper;
 import frc.robot.utilities.PicoColorSensor;
 import frc.robot.utilities.PicoColorSensor.RawColor;
 
@@ -25,8 +25,8 @@ public class Gripper extends SubsystemBase {
 
   public Gripper() {
     // Sets the motor controllers to inverted if needed
-    gripperNeo1.setInverted(!GripperConstants.inverted);
-    gripperNeo2.setInverted(GripperConstants.inverted);
+    gripperNeo1.setInverted(!kGripper.inverted);
+    gripperNeo2.setInverted(kGripper.inverted);
 
     colorSensor = new PicoColorSensor();
     colorSensor.setDebugPrints(false);
@@ -53,7 +53,7 @@ public class Gripper extends SubsystemBase {
     int proximity = colorSensor.getProximity0();
     RawColor color = colorSensor.getRawColor0();
 
-    if (proximity > kSensors.proximityThreshold) {
+    if (proximity > kGripper.proximityThreshold) {
       double colorRatio = (double) color.blue / (double) color.green;
       if (4 < colorRatio && colorRatio < 8) return GamePiece.CONE;
       else if (0 < colorRatio && colorRatio < 2) return GamePiece.KUBE;

--- a/src/main/java/frc/robot/subsystems/Gripper.java
+++ b/src/main/java/frc/robot/subsystems/Gripper.java
@@ -5,7 +5,6 @@ import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 import edu.wpi.first.wpilibj.motorcontrol.MotorControllerGroup;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.Constants.ArmConstants.GripperConstants;
 import frc.robot.Constants.CanId;
 import frc.robot.Constants.GamePiece;
 import frc.robot.Constants.kGripper;
@@ -64,7 +63,7 @@ public class Gripper extends SubsystemBase {
   public Command intakeCommand() {
 
     return this.startEnd(
-            () -> setVoltage(GripperConstants.intakeVel),
+            () -> setVoltage(kGripper.intakeVel),
             () -> {
               setVoltage(0);
               gameState = getGamePiece();
@@ -74,7 +73,7 @@ public class Gripper extends SubsystemBase {
 
   public Command ejectCommand() {
     return this.startEnd(
-            () -> setVoltage(GripperConstants.ejectVel),
+            () -> setVoltage(kGripper.ejectVel),
             () -> {
               setVoltage(0);
               gameState = getGamePiece();

--- a/src/main/java/frc/robot/subsystems/Indications.java
+++ b/src/main/java/frc/robot/subsystems/Indications.java
@@ -4,7 +4,7 @@ import edu.wpi.first.wpilibj.AddressableLED;
 import edu.wpi.first.wpilibj.AddressableLEDBuffer;
 import edu.wpi.first.wpilibj.util.Color;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.Constants.kSensors;
+import frc.robot.Constants.kIndications;
 import frc.robot.utilities.LEDSubStrip;
 
 public class Indications extends SubsystemBase {
@@ -15,8 +15,8 @@ public class Indications extends SubsystemBase {
 
   public Indications() {
     // TODO Add constants for start and end locations and move strip constants out of kSensors
-    armLEDs = new AddressableLED(kSensors.ledPort);
-    armLEDsBuffer = new AddressableLEDBuffer(kSensors.ledLength);
+    armLEDs = new AddressableLED(kIndications.ledPort);
+    armLEDsBuffer = new AddressableLEDBuffer(kIndications.ledLength);
     proximalLeftStrip = new LEDSubStrip(armLEDsBuffer, 0, 60);
     armLEDs.setData(armLEDsBuffer);
     armLEDs.start();


### PR DESCRIPTION
- Switched to a Linear State Space Model of the DT and accompanying acceleration limiting/feedforward
- Split driveVoltages into limited and nonlimited acceleration
- Fixed Feedforward using feedback instead of last set speeds
- Ignore more sim/tool files
- Update constants to reorganize/remove unused values and move to a shorter and more consistent naming convention
- Fix encoder bugs and first running drivetrain code
- Git data logging and photonvision in sim

Headline items are a statespace model for the drivetrain control (LTVDifferentialDirveCommand comming later), which was tested on the chassis' first drive, and updates to the constants naming and organization.

I also slipped in some logging code that starts a log and adds the latest deploy git data.

Fixes: #34 
Fixes: #32 
