### PR TITLE
Update .gitattributes to not modify .png files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text eol=lf
+*.png binary


### PR DESCRIPTION
All of the pull requests have the `Media/Robot.png` modified. I think this is because the current entry in `.gitattributes` always blindly changes `CR-LF` to `LF`. Adding an entry for `*.png` as `binary` should resolve this problem.