### PR TITLE
Auto routine container and selector with some small bug fixes/clean up

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -4,10 +4,8 @@
 
 package frc.robot;
 
-import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.WaitCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandJoystick;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
@@ -15,6 +13,7 @@ import frc.robot.Constants.OperatorInterface;
 import frc.robot.Constants.OperatorInterface.Bindings;
 import frc.robot.Constants.armState;
 import frc.robot.commands.ArmGripperCommands;
+import frc.robot.commands.AutoRoutines;
 import frc.robot.commands.TurretManual;
 import frc.robot.commands.UserArcadeDrive;
 import frc.robot.subsystems.Arm;
@@ -40,7 +39,7 @@ public class RobotContainer {
   private final Arm arm = new Arm();
   private final Gripper gripper = new Gripper();
   private final ArmGripperCommands armGripperCommands = new ArmGripperCommands(arm, gripper);
-  private final SendableChooser<Command> autoSelect = new SendableChooser<Command>();
+  private final AutoRoutines autoRoutines = new AutoRoutines(drivetrain, arm, gripper);
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {
@@ -53,10 +52,8 @@ public class RobotContainer {
             () -> driverController.getRightTriggerAxis() > 0.1,
             drivetrain));
 
-    autoSelect.setDefaultOption("Do nothing", new WaitCommand(0));
-    autoSelect.addOption("Mobility", drivetrain.mobilityAuto());
-    autoSelect.addOption("Auto Balance", drivetrain.AutoBalanceCommand());
-    SmartDashboard.putData("Auto Selector", autoSelect);
+    // Post sendable chooser for auto
+    Shuffleboard.getTab("Auto").add("Auto selector", autoRoutines.getChooser()).withSize(3, 1);
 
     // Configure the trigger bindings
     configureBindings();
@@ -94,7 +91,7 @@ public class RobotContainer {
    * @return the command to run in autonomous
    */
   public Command getAutoCommand() {
-    return null;
+    return autoRoutines.getChooser().getSelected();
   }
 
   public Command getTelopInitCommand() {

--- a/src/main/java/frc/robot/commands/AutoRoutines.java
+++ b/src/main/java/frc/robot/commands/AutoRoutines.java
@@ -1,0 +1,49 @@
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.Arm;
+import frc.robot.subsystems.Drivetrain;
+import frc.robot.subsystems.Gripper;
+import java.util.HashMap;
+import java.util.Map;
+
+public class AutoRoutines {
+  private final Drivetrain drivetrain;
+  private final Arm arm;
+  private final Gripper gripper;
+
+  private final HashMap<String, Command> routineMap = new HashMap<String, Command>();
+  private final SendableChooser<Command> selector = new SendableChooser<Command>();
+
+  public AutoRoutines(Drivetrain drivetrain, Arm arm, Gripper gripper) {
+    this.drivetrain = drivetrain;
+    this.arm = arm;
+    this.gripper = gripper;
+
+    loadRoutines();
+    populateSendable();
+  }
+
+  /**
+   * Get the sendable chooser object
+   *
+   * @return the sendable chooser object
+   */
+  public SendableChooser<Command> getChooser() {
+    return selector;
+  }
+
+  // Auto paths go here
+  private void loadRoutines() {
+    routineMap.put("No Auto", gripper.intakeCommand());
+  }
+
+  // Iterate over hashmap and add routines to sendable
+  private void populateSendable() {
+    selector.setDefaultOption("No Auto", routineMap.get("No Auto"));
+    for (Map.Entry<String, Command> entry : routineMap.entrySet()) {
+      selector.addOption(entry.getKey(), entry.getValue());
+    }
+  }
+}

--- a/src/main/java/frc/robot/subsystems/Arm.java
+++ b/src/main/java/frc/robot/subsystems/Arm.java
@@ -444,7 +444,7 @@ public class Arm extends SubsystemBase {
   // Get the controller's applied output
   private Matrix<N2, N1> getArmVoltages() {
     return new MatBuilder<N2, N1>(Nat.N2(), Nat.N1())
-        .fill(proximalNEO1.getAppliedOutput() * 12, forearmNEO.getAppliedOutput() * 12);
+        .fill(proximalNEO1.getAppliedOutput(), forearmNEO.getAppliedOutput());
   }
 
   private void setArmVoltages(Matrix<N2, N1> voltages) {

--- a/src/main/java/frc/robot/subsystems/Arm.java
+++ b/src/main/java/frc/robot/subsystems/Arm.java
@@ -386,7 +386,7 @@ public class Arm extends SubsystemBase {
         new double[] {state.get(0, 0), state.get(1, 0), state.get(2, 0), state.get(3, 0)});
     logCalculatedVoltages.append(new double[] {armVoltages.get(0, 0), armVoltages.get(1, 0)});
     logActualVoltages.append(
-        new double[] {proximalNEO1.getAppliedOutput(), forearmNEO.getAppliedOutput()});
+        new double[] {proximalNEO1.getAppliedOutput() * 12, forearmNEO.getAppliedOutput() * 12});
     //
     proximal2d.setAngle(Units.radiansToDegrees(getArmMeasuredStates().get(0, 0)));
     forearm2d.setAngle(Units.radiansToDegrees(getArmMeasuredStates().get(1, 0)));

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -139,6 +139,8 @@ public class Drivetrain extends SubsystemBase {
       new DoubleArrayLogEntry(log, "Drivetrain/poseEstimate");
   private DoubleArrayLogEntry logPhotonPose = new DoubleArrayLogEntry(log, "Drivetrain/photonPose");
   private DoubleLogEntry logGyro = new DoubleLogEntry(log, "Drivetrain/gyro");
+  private DoubleArrayLogEntry logFilteredVelocity =
+      new DoubleArrayLogEntry(log, "Drivetrain/filteredVelocity");
 
   // Constructor taking no arguments, all relevant values are defined in Constants.java
   public Drivetrain() {
@@ -356,6 +358,8 @@ public class Drivetrain extends SubsystemBase {
         new double[] {photonPose.getX(), photonPose.getY(), photonPose.getRotation().getRadians()});
     logLastWheelSpeeds.append(
         new double[] {lastSpeeds.leftMetersPerSecond, lastSpeeds.rightMetersPerSecond});
+    logFilteredVelocity.append(
+        new double[] {encoderSpeeds.leftMetersPerSecond, encoderSpeeds.rightMetersPerSecond});
   }
 
   @Override
@@ -395,9 +399,5 @@ public class Drivetrain extends SubsystemBase {
         .withWidget(BuiltInWidgets.kField)
         .withSize(7, 4)
         .withPosition(2, 0);
-    SBTab.addDouble("Left Voltage", () -> leftLead.getAppliedOutput() * 12);
-    SBTab.addDouble("Right Voltage", () -> rightLead.getAppliedOutput() * 12);
-    SBTab.addDouble("Left Speed", () -> getSpeeds().leftMetersPerSecond);
-    SBTab.addDouble("Right Speed", () -> getSpeeds().rightMetersPerSecond);
   }
 }

--- a/src/main/java/frc/robot/subsystems/Gripper.java
+++ b/src/main/java/frc/robot/subsystems/Gripper.java
@@ -79,6 +79,10 @@ public class Gripper extends SubsystemBase {
     return GamePiece.NONE;
   }
 
+  public Command intakeCommand() {
+    return intakeCommand(GamePiece.KUBE);
+  }
+
   public Command intakeCommand(GamePiece Piece) {
     return this.startEnd(
             () -> {


### PR DESCRIPTION
`AutoRoutines` holds a hashmap of commands with the appropriate names and automatically populates a sendable chooser object for use on the dashboard

Closes: #96 
Closes: #94 

- Add gripper intake command override for no gamepiece
- Fix sim bug
- Auto routine container class and selector
- Actually fixed sim bug this time
- Log filtered velocities
